### PR TITLE
Fixed missing DLLs & DLL export symbols for Windows builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,6 +39,8 @@ build_script:
 
     nmake
 
+    mkdir C:\prj\deca\root
+
     mkdir C:\prj\deca\root\bin
     
     mkdir C:\prj\deca\root\lib
@@ -46,6 +48,21 @@ build_script:
     copy C:\prj\deca\build\cpp\bin2xml\bin2xml* C:\prj\deca\root\bin\ 
     
     copy C:\prj\deca\build\cpp\process_image\process_image* C:\prj\deca\root\lib\ 
+
+    copy C:\prj\deca\build\extern\HavokLib\source\havok.dll C:\prj\deca\root\bin\
+
+    copy C:\prj\deca\build\extern\HavokLib\3rd_party\PreCore\precore6.dll C:\prj\deca\root\bin\
+
+    copy C:\prj\deca\build\extern\HavokLib\3rd_party\PreCore\3rd_party\3rd_party\glm\glm\glm_shared.dll
+
+    copy C:\prj\deca\build\extern\HavokLib\3rd_party\PreCore\3rd_party\pugixml\pugixml1.dll C:\prj\deca\root\bin\
+
+
+    echo UN-PATCH external libs
+    
+    cd c:\prj\deca\extern\HavokLib\3rd_party\PreCore
+    
+    git apply -R c:\prj\deca\patch\pre_core.patch
 
 
     echo SETUP PYTHON

--- a/cpp/process_image/CMakeLists.txt
+++ b/cpp/process_image/CMakeLists.txt
@@ -4,6 +4,16 @@ project(process_image)
 
 # gcc -fPIC -shared -O3 deca/process_image.c -o process_image.so
 
+# Some versions of CMake don't define _USRDLL and _WINDLL macros for a shared libraries.
+# It will cause lack of __declspec(dllexport) declaration and produce an empty DLLs on Windows.
+# We should add _USRDLL and _WINDLL flags here for MSVC.
+if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+  set(CMAKE_C_FLAGS_DEBUG "/D_USRDLL /D_WINDLL /MT")
+  set(CMAKE_C_FLAGS_RELEASE "/D_USRDLL /D_WINDLL /MT")
+  set(CMAKE_CXX_FLAGS_DEBUG "/D_USRDLL /D_WINDLL /MT")
+  set(CMAKE_CXX_FLAGS_RELEASE "/D_USRDLL /D_WINDLL /MT")
+endif()
+
 add_library(
 	process_image
 	SHARED

--- a/python/deca/deca/dxgi.py
+++ b/python/deca/deca/dxgi.py
@@ -590,9 +590,9 @@ def process_image(*args, **kwargs):
 
         if process_image_func is None:
             # "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
-            # "cl.exe /D_USRDLL /D_WINDLL deca/process_image.c /link /DLL /OUT:process_image.dll"
+            # "cl.exe /D_USRDLL /D_WINDLL cpp/process_image/deca/process_image.c /link /DLL /OUT:process_image.dll"
 
-            # gcc -fPIC -shared -O3 deca/process_image.c -o process_image.so
+            # gcc -fPIC -shared -O3 cpp/process_image/process_image.c -o process_image.so
             paths = [
                 "process_image.dll",
                 os.path.join(lib_path, "process_image.dll"),


### PR DESCRIPTION
Fixed issues:
1. **process_image.dll** has no export symbols.
2. **bin2xml.exe** miss **havok.dll**, **precore6.dll**, **glm_shared.dll**, **pugixml1.dll**