### PR TITLE
chore(.gitmodules): Update submodule link

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "extern/HavokLib"]
 	path = extern/HavokLib
-	url = git@github.com:kk49/HavokLib.git
+	url = https://github.com/kk49/HavokLib.git


### PR DESCRIPTION
This fixes the inability to clone the repo with `--recurse-submodules` via Git CLI.